### PR TITLE
Build project on Azure Devops

### DIFF
--- a/AmiKoWindows/Source/Utilities.cs
+++ b/AmiKoWindows/Source/Utilities.cs
@@ -33,7 +33,7 @@ using System.Windows.Media.Imaging;
 
 namespace AmiKoWindows
 {
-    class Utilities
+    public class Utilities
     {
         public static string AppCultureInfoName()
         {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,16 +32,10 @@ steps:
     script: |
       choco install windows-sdk-8.1
 
-- task: CmdLine@2
+- task: PowerShell@2
   inputs:
-    script: 'dir "C:\Program Files (x86)\Windows Kits\8.1\"'
-
-- task: MSBuild@1
-  inputs:
-    platform: 'x86'
-    solution: '$(solution)'
-    configuration: '$(buildConfiguration)'
-    msbuildArguments: '/t:AmikoDesitin /p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+    filePath: '.\download.ps1'
+    errorActionPreference: 'continue'
 
 - task: VSBuild@1
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,27 @@ steps:
   inputs:
     restoreSolution: '$(solution)'
 
+- task: CmdLine@2
+  inputs:
+    script: |
+      @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      choco install windows-sdk-8.1
+
+- task: CmdLine@2
+  inputs:
+    script: 'dir "C:\Program Files (x86)\Windows Kits\8.1\"'
+
+- task: MSBuild@1
+  inputs:
+    platform: 'x86'
+    solution: '$(solution)'
+    configuration: '$(buildConfiguration)'
+    msbuildArguments: '/t:AmikoDesitin /p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+
 - task: VSBuild@1
   inputs:
     platform: 'x86'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,3 +43,15 @@ steps:
     solution: '$(solution)'
     configuration: '$(buildConfiguration)'
     msbuildArgs: '/p:AppxBundlePlatforms="$(buildPlatform)" /p:AppxPackageDir="$(appxPackageDir)" /p:AppxBundle=Always /p:UapAppxPackageBuildMode=StoreUpload'
+
+- task: CopyFiles@2
+  displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+  inputs:
+    SourceFolder: '$(system.defaultworkingdirectory)'
+    Contents: '**\bin\$(BuildConfiguration)\**'
+    TargetFolder: '$(build.artifactstagingdirectory)'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: Build Result'
+  inputs:
+    PathtoPublish: '$(build.artifactstagingdirectory)'

--- a/download.ps1
+++ b/download.ps1
@@ -1,0 +1,46 @@
+New-Item -ItemType directory -Path AmiKoWindows/Data/de
+New-Item -ItemType directory -Path AmiKoWindows/Data/fr
+
+# AmiKoDesitin
+cd AmiKoWindows/Data/de
+
+# Remove-Item amiko_db_full_idx_de.db
+# Remove-Item amiko_frequency_de.db
+# Remove-Item amiko_report_de.html
+# Remove-Item drug_interactions_csv_de.csv
+
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_report_de.html -OutFile amiko_report_de.html
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_db_full_idx_de.zip -OutFile amiko_db_full_idx_de.zip
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_frequency_de.db.zip -OutFile amiko_frequency_de.db.zip
+Invoke-WebRequest -Uri http://pillbox.oddb.org/drug_interactions_csv_de.zip -OutFile drug_interactions_csv_de.zip
+
+Expand-Archive -Force -Path amiko_db_full_idx_de.zip -DestinationPath .
+Expand-Archive -Force -Path amiko_frequency_de.db.zip -DestinationPath .
+Expand-Archive -Force -Path drug_interactions_csv_de.zip -DestinationPath .
+
+Remove-Item amiko_db_full_idx_de.zip
+Remove-Item amiko_frequency_de.db.zip
+Remove-Item drug_interactions_csv_de.zip
+
+# CoMedDesitin
+cd ../fr
+
+# Remove-Item amiko_db_full_idx_fr.db
+# Remove-Item amiko_frequency_fr.db
+# Remove-Item amiko_report_fr.html
+# Remove-Item drug_interactions_csv_fr.csv
+
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_report_fr.html -OutFile amiko_report_fr.html
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_db_full_idx_fr.zip -OutFile amiko_db_full_idx_fr.zip
+Invoke-WebRequest -Uri http://pillbox.oddb.org/amiko_frequency_fr.db.zip -OutFile amiko_frequency_fr.db.zip
+Invoke-WebRequest -Uri http://pillbox.oddb.org/drug_interactions_csv_fr.zip -OutFile drug_interactions_csv_fr.zip
+
+Expand-Archive -Force -Path amiko_db_full_idx_fr.zip -DestinationPath .
+Expand-Archive -Force -Path amiko_frequency_fr.db.zip -DestinationPath .
+Expand-Archive -Force -Path drug_interactions_csv_fr.zip -DestinationPath .
+
+Remove-Item amiko_db_full_idx_fr.zip
+Remove-Item amiko_frequency_fr.db.zip
+Remove-Item drug_interactions_csv_fr.zip
+
+cd ../../..


### PR DESCRIPTION
#188 

Running `download.ps1` in Powershell now downloads the latest resources.

On Azure Devops:

- It downloads the latest database automatically
- It builds both Amiko and Comed
- It copies file to the `Artifacts` section of the build
- It does not build .msi file and .appx file yet.

Building .msi and .appx seems to be difficult because packaging as .msi files requires [Visual Studio Installer Projects](https://marketplace.visualstudio.com/items?itemName=VisualStudioClient.MicrosoftVisualStudio2017InstallerProjects) and .appx requires [Desktop App Converter](https://www.microsoft.com/en-us/p/desktop-app-converter/9nblggh4skzw#activetab=pivot:overviewtab), but both of them [cannot](https://stackoverflow.com/questions/54908015/how-to-build-visual-studio-installer-project-in-azure-devops-pipeline-hosted-age) be installed on Azure Devops.

One solution will be setting up our own Windows build server (private agent), but it seems like a big infrastructure to maintain.