### PR TITLE
Add source to nuget

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,4 +3,7 @@
   <config>
     <add key="repositoryPath" value="Packages" />
   </config>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
 </configuration>


### PR DESCRIPTION
Try to see if this fix #202, the build on AppCenter cannot find any package, and there is a warning about config does not contain any source